### PR TITLE
Fixed flaky test-case in the class (orika/core): BeanToArrayGenerationTestCase.testBeanToArrayGeneration 

### DIFF
--- a/core/src/test/java/ma/glasnost/orika/test/generator/BeanToArrayGenerationTestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/generator/BeanToArrayGenerationTestCase.java
@@ -41,6 +41,8 @@ public class BeanToArrayGenerationTestCase {
                 .field("grade.percentage", "2")
                 .field("name.first", "3")
                 .field("name.last", "4")
+                .field("id", "5")
+                .field("email", "6")
                 .byDefault()
                 .register();
         

--- a/pom.xml
+++ b/pom.xml
@@ -261,11 +261,6 @@
                     <additionalJOption>-Xdoclint:none</additionalJOption>
                 </configuration>
             </plugin>
-            <plugin> <!-- for flaky testing -->
-                <groupId>edu.illinois</groupId>
-                <artifactId>nondex-maven-plugin</artifactId>
-                <version>2.1.7</version>
-            </plugin>
         </plugins>
 
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,11 @@
                     <additionalJOption>-Xdoclint:none</additionalJOption>
                 </configuration>
             </plugin>
+            <plugin> <!-- for flaky testing -->
+                <groupId>edu.illinois</groupId>
+                <artifactId>nondex-maven-plugin</artifactId>
+                <version>2.1.7</version>
+            </plugin>
         </plugins>
 
     </build>


### PR DESCRIPTION
POINT OF FAILURE -> random attribute ordering produced by factory.classMap(Clazz, Clazz) **When field(*fromClassField*, *toClassField*) is not called for all hierarchical attributes, the one left out will appear in random order.**

Example:
``` 
{
"a" : 1,
"b" : {
   "c": 2,
   "d": 3
}
}
```
and when --""--.field("b.c", "0") is called, (converting obj to Object[ ])

the mapped destination Object[ ] could be: [2, 1, 3] OR [2, 3, 1]

***

Possible fix: for all unmapped attrs, use lexographical ordering or throw exception

Fixed using NonDex, plugin added in parent pom.
Suggested command to check flaky tests :
> mvn nondex:nondex

For particular test:
Add the following lines to your pom.xml
```
  <plugin> <!-- for flaky testing -->
      <groupId>edu.illinois</groupId>
      <artifactId>nondex-maven-plugin</artifactId>
      <version>2.1.7</version>
  </plugin>
```
and run
>mvn -pl ./core nondex:nondex -Dtest=ma.glasnost.orika.test.generator.BeanToArrayGenerationTestCase#testBeanToArrayGeneration -DnondexRuns=10

**OR**

>mvn -pl ./core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=ma.glasnost.orika.test.generator.BeanToArrayGenerationTestCase#testBeanToArrayGeneration -DnondexRuns=10

For more information : https://github.com/TestingResearchIllinois/NonDex